### PR TITLE
Treasury comission from validator rewards

### DIFF
--- a/docs/tokenomics.md
+++ b/docs/tokenomics.md
@@ -34,9 +34,9 @@ After 30 years the APY stabilizes at 2%
 
 * Initial total supply is not implemented as it requires more detailed composition.
 * 18 decimals is done. (configured by MILLIGGX)
-* APY configured to 16%. (configured by runtime/mainnet/src/pos/inflation.rs)
+* APY configured to 16%. (configured by runtime/mainnet/src/pos/inflation.rs InflationPercent)
 * APY decrease ladder scheduled for the runtime.
-APY decrease happens every 365.25 days to address leap years. (configured by runtime/mainnet/src/pos/inflation.rs)
+APY decrease happens every 365.25 days to address leap years. (configured by runtime/mainnet/src/pos/inflation.rs InflationPercentDecay)
 
 ## Staking
 
@@ -80,7 +80,7 @@ Slashed amounts are sent to treasury.
 (configured by EpochDurationInBlocks, SessionsPerEra).
 This can be hard to configure using Parity toolchain, cause they use era as payout and validator rotation point.
 * Fixed comission is not implemented yet. Currently, validator can set any comission it wants.
-* Tresuary cut from validators reward is not implemented yet.
+* 10% Treasury comission is implemented. (configured by runtime/mainnet/src/pos/inflation.rs TreasuryCommission)
 
 ## Rewards
 

--- a/docs/tokenomics.md
+++ b/docs/tokenomics.md
@@ -114,5 +114,5 @@ Parameters can be changed by OpenGov.
 
 ### Current state
 
-* APY can be managed by OpenGov
+* APY, APY Decay, Treasury comission from validators can be managed by OpenGov
 * Everything else is not yet configurable.

--- a/node/src/service/mainnet.rs
+++ b/node/src/service/mainnet.rs
@@ -11,6 +11,7 @@ use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderMetadata};
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
+use sp_core::crypto::Ss58AddressFormat;
 
 use crate::{
 	cli::Cli,
@@ -48,6 +49,10 @@ pub fn new_partial(
 			"Remote Keystores are not supported.".into(),
 		));
 	}
+
+	sp_core::crypto::set_default_ss58_version(Ss58AddressFormat::custom(
+		crate::runtime::SS58Prefix::get(),
+	));
 
 	let telemetry = config
 		.telemetry_endpoints

--- a/node/src/service/testnet.rs
+++ b/node/src/service/testnet.rs
@@ -28,7 +28,7 @@ use sc_telemetry::{Telemetry, TelemetryWorker};
 use sc_transaction_pool::{ChainApi, Pool};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
-use sp_core::U256;
+use sp_core::{crypto::Ss58AddressFormat, U256};
 use sp_runtime::traits::BlakeTwo256;
 // Frontier
 use fc_consensus::FrontierBlockImport;
@@ -101,6 +101,10 @@ pub fn new_partial(
 			"Remote Keystores are not supported.".to_string(),
 		));
 	}
+
+	sp_core::crypto::set_default_ss58_version(Ss58AddressFormat::custom(
+		crate::runtime::SS58Prefix::get(),
+	));
 
 	let telemetry = config
 		.telemetry_endpoints


### PR DESCRIPTION
* Implemented treasury commission from validator's reward.
* Fixed bug with ss58 prefix that user couldn't make any transaction cause node haven't had configured prefix.