### PR TITLE
Node compilation for mainnet

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -177,13 +177,25 @@
             };
 
             common-native-release-attrs = common-attrs // rec {
-              cargoExtraArgs = "--package ${pname}";
+              cargoExtraArgs = ''--package ${pname}  --no-default-features --features="aura,with-rocksdb-weights,$RUNTIME"'';
               pname = "golden-gate-node";
+              nativeBuildInputs = common-attrs.nativeBuildInputs ++ [ pkgs.git ]; # parity does some git hacks in build.rs
+            };
+
+            common-native-mainnet-attrs = common-native-release-attrs // rec {
+              RUNTIME="mainnet";
               version = "0.1.0";
             };
 
-            common-native-release-deps =
-              craneLib.buildDepsOnly (common-native-release-attrs // { });
+            common-native-testnet-attrs = common-native-release-attrs // rec {
+              RUNTIME="testnet";
+              version = "0.2.0";
+            };
+
+            common-native-release-mainnet-deps =
+              craneLib.buildDepsOnly (common-native-mainnet-attrs // { });
+            common-native-release-testnet-deps =
+              craneLib.buildDepsOnly (common-native-testnet-attrs // { });
             common-wasm-release-deps = craneLib.buildDepsOnly common-wasm-deps-attrs;
 
             golden-gate-runtimes = craneLib.buildPackage (common-wasm-attrs // rec {
@@ -191,9 +203,12 @@
               cargoArtifacts = common-wasm-release-deps;
             });
 
-            golden-gate-node = craneLib.buildPackage (common-native-release-attrs // {
-              cargoArtifacts = common-native-release-deps;
-              nativeBuildInputs = common-native-release-attrs.nativeBuildInputs ++ [ pkgs.git ]; # parity does some git hacks in build.rs 
+            golden-gate-node-mainnet = craneLib.buildPackage (common-native-mainnet-attrs // {
+              cargoArtifacts = common-native-release-mainnet-deps;
+            });
+
+            golden-gate-node-testnet = craneLib.buildPackage (common-native-testnet-attrs // {
+              cargoArtifacts = common-native-release-testnet-deps;
             });
 
             fmt = craneLib.cargoFmt (common-attrs // {
@@ -203,48 +218,20 @@
 
             cargoClippyExtraArgs = "-- -D warnings";
 
-            clippy-node = craneLib.cargoClippy (common-native-release-attrs // {
+            clippy-node-testnet = craneLib.cargoClippy (common-native-testnet-attrs // {
               inherit cargoClippyExtraArgs;
-              cargoArtifacts = golden-gate-node.cargoArtifacts;
+              cargoArtifacts = golden-gate-node-testnet.cargoArtifacts;
+            });
+
+            clippy-node-mainnet = craneLib.cargoClippy (common-native-mainnet-attrs // {
+              inherit cargoClippyExtraArgs;
+              cargoArtifacts = golden-gate-node-mainnet.cargoArtifacts;
             });
 
             clippy-wasm = craneLib.cargoClippy (common-wasm-deps-attrs // {
               inherit cargoClippyExtraArgs;
               cargoArtifacts = golden-gate-runtimes.cargoArtifacts;
             });
-
-
-
-            # really need to run as some points:
-            # - light client emulator (ideal for contracts)
-            # - multi node local fast (fast druation low security)
-            # - multi local slow (duration and security as in prod)
-            # - here can apply above to remote with something if needed (terranix/terraform-ng works)
-            # for each 
-            # - either start from genesis
-            # - of from fork (remote prod data)
-            # all with - archieval and logging enabled
-            single-fast = pkgs.writeShellApplication rec {
-              name = "single-fast";
-              text = ''
-                ${pkgs.lib.meta.getExe golden-gate-node} --dev  
-              '';
-            };
-
-            # we do not use existing Dotsama tools as they target relay + parachains
-            # here we can evolve into generating arion/systemd/podman/k8s output (what ever will fit) easy 
-            multi-fast = pkgs.writeShellApplication rec {
-              name = "multi-fast";
-              text = ''
-                WS_PORT_ALICE=''${WS_PORT_ALICE:-9944}
-                WS_PORT_BOB=''${WS_PORT_BOB:-9945}
-                WS_PORT_CHARLIE=''${WS_PORT_CHARLIE:-9946}
-                ( ${pkgs.lib.meta.getExe golden-gate-node} --chain=local --rpc-cors=all --alice --tmp --ws-port="$WS_PORT_ALICE" &> alice.log ) &
-                ( ${pkgs.lib.meta.getExe golden-gate-node} --chain=local --rpc-cors=all --bob --tmp --ws-port="$WS_PORT_BOB" &> bob.log ) &
-                ( ${pkgs.lib.meta.getExe golden-gate-node} --chain=local --rpc-cors=all --charlie --tmp --ws-port="$WS_PORT_CHARLIE" &> charlie.log ) &
-                echo https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:"$WS_PORT_ALICE"#/explorer
-              '';
-            };
 
             tf-init = pkgs.writeShellApplication rec {
               name = "tf-init";
@@ -405,12 +392,13 @@
 
             packages = flake-utils.lib.flattenTree
               rec  {
-                inherit fix golden-gate-runtimes golden-gate-node gen-node-key single-fast multi-fast tf-base tf-testnet node-image inspect-node-key doclint fmt clippy-node clippy-wasm;
+                inherit fix golden-gate-runtimes golden-gate-node-testnet golden-gate-node-mainnet gen-node-key tf-base tf-testnet node-image inspect-node-key doclint fmt clippy-node-testnet clippy-node-mainnet clippy-wasm;
                 subkey = pkgs.subkey;
+                golden-gate-node = golden-gate-node-testnet;
                 node = golden-gate-node;
                 lint-all = pkgs.symlinkJoin {
                   name = "lint-all";
-                  paths = [ doclint fmt clippy-node clippy-wasm ];
+                  paths = [ doclint fmt clippy-node-testnet clippy-node-mainnet clippy-wasm ];
                 };
                 release = pkgs.symlinkJoin {
                   name = "release";
@@ -425,6 +413,39 @@
                   name = "prune-running";
                   text = ''
                     pkill golden-gate-nod 
+                  '';
+                };
+
+                # really need to run as some points:
+                # - light client emulator (ideal for contracts)
+                # - multi node local fast (fast druation low security)
+                # - multi local slow (duration and security as in prod)
+                # - here can apply above to remote with something if needed (terranix/terraform-ng works)
+                # for each 
+                # - either start from genesis
+                # - of from fork (remote prod data)
+                # all with - archieval and logging enabled
+                single-fast = pkgs.writeShellApplication rec {
+                  name = "single-fast";
+                  text = ''
+                    [[ ''${1:-""} == "mainnet" ]] && package=${pkgs.lib.meta.getExe golden-gate-node-mainnet} || package=${pkgs.lib.meta.getExe golden-gate-node-testnet}
+                    $package --dev  
+                  '';
+                };
+
+                # we do not use existing Dotsama tools as they target relay + parachains
+                # here we can evolve into generating arion/systemd/podman/k8s output (what ever will fit) easy 
+                multi-fast = pkgs.writeShellApplication rec {
+                  name = "multi-fast";
+                  text = ''
+                    [[ ''${1:-""} == "mainnet" ]] && package=${pkgs.lib.meta.getExe golden-gate-node-mainnet} || package=${pkgs.lib.meta.getExe golden-gate-node-testnet}
+                    WS_PORT_ALICE=''${WS_PORT_ALICE:-9944}
+                    WS_PORT_BOB=''${WS_PORT_BOB:-9945}
+                    WS_PORT_CHARLIE=''${WS_PORT_CHARLIE:-9946}
+                    ( $package --chain=local --rpc-cors=all --alice --tmp --ws-port="$WS_PORT_ALICE" &> alice.log ) &
+                    ( $package --chain=local --rpc-cors=all --bob --tmp --ws-port="$WS_PORT_BOB" &> bob.log ) &
+                    ( $package --chain=local --rpc-cors=all --charlie --tmp --ws-port="$WS_PORT_CHARLIE" &> charlie.log ) &
+                    echo https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:"$WS_PORT_ALICE"#/explorer
                   '';
                 };
 

--- a/node/src/service/mainnet.rs
+++ b/node/src/service/mainnet.rs
@@ -101,7 +101,7 @@ pub fn new_partial(
 
 	let (grandpa_block_import, grandpa_link) = sc_finality_grandpa::block_import(
 		client.clone(),
-		&(client.clone() as Arc<_>),
+		&Arc::clone(&client),
 		select_chain.clone(),
 		telemetry.as_ref().map(|x| x.handle()),
 	)?;

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -127,7 +127,7 @@ pub mod opaque {
 }
 
 /// The address format for describing accounts.
-pub type Address = sp_runtime::MultiAddress<AccountId, AccountIndex>;
+pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.
@@ -192,8 +192,8 @@ parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 1 seconds of compute with a 2 second average block time.
-	pub const MaximumBlockWeight: Weight = Weight::from_parts(
-		(2) * WEIGHT_REF_TIME_PER_SECOND,
+	pub storage MaximumBlockWeight: Weight = Weight::from_parts(
+		(RuntimeSpecification::chain_spec().block_time_in_millis / 1000) * WEIGHT_REF_TIME_PER_SECOND,
 		u64::MAX,
 	);
 	pub BlockWeights: frame_system::limits::BlockWeights =  frame_system::limits::BlockWeights::builder()
@@ -248,7 +248,7 @@ impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-	type Lookup = AccountIdLookup<AccountId, AccountIndex>;
+	type Lookup = AccountIdLookup<AccountId, ()>;
 	/// The header type.
 	type Header = generic::Header<BlockNumber, BlakeTwo256>;
 	/// The ubiquitous event type.

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -127,7 +127,7 @@ pub mod opaque {
 }
 
 /// The address format for describing accounts.
-pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
+pub type Address = sp_runtime::MultiAddress<AccountId, AccountIndex>;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.
@@ -192,8 +192,8 @@ parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 1 seconds of compute with a 2 second average block time.
-	pub storage MaximumBlockWeight: Weight = Weight::from_parts(
-		(RuntimeSpecification::chain_spec().block_time_in_millis / 1000) * WEIGHT_REF_TIME_PER_SECOND,
+	pub const MaximumBlockWeight: Weight = Weight::from_parts(
+		(2) * WEIGHT_REF_TIME_PER_SECOND,
 		u64::MAX,
 	);
 	pub BlockWeights: frame_system::limits::BlockWeights =  frame_system::limits::BlockWeights::builder()
@@ -248,7 +248,7 @@ impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-	type Lookup = AccountIdLookup<AccountId, ()>;
+	type Lookup = AccountIdLookup<AccountId, AccountIndex>;
 	/// The header type.
 	type Header = generic::Header<BlockNumber, BlakeTwo256>;
 	/// The ubiquitous event type.


### PR DESCRIPTION
* Added build and clippy linting for mainnet node to CI. 
* Added possibility to choose runtime in nix helper utilities
* Fixed the issue that AccountIndex wasn't used.
* Added some tests to mainnet.

The tests were added from the [substrate node](https://github.com/paritytech/substrate/blob/master/bin/node/runtime/src/lib.rs).
