### PR TITLE
fixed possibility to extend validators and run like 1 validator

### DIFF
--- a/node/src/runtime/mainnet.rs
+++ b/node/src/runtime/mainnet.rs
@@ -84,11 +84,9 @@ pub fn testnet_genesis(
 		transaction_payment: Default::default(),
 		treasury: Default::default(),
 		staking: StakingConfig {
-			validator_count: initial_authorities.len() as u32,
-			minimum_validator_count: 2,
-			max_validator_count: Some(100),
+			validator_count: 100,
+			minimum_validator_count: 1,
 			invulnerables: vec![],
-			slash_reward_fraction: sp_runtime::Perbill::from_percent(10),
 			stakers: endowed_accounts
 				.iter()
 				.map(|user| {


### PR DESCRIPTION
Basically changed to make test configuration more applicable to Sydney release:
* validator_count up to 100 (desired amount)
* minimum_validator_count made 1 to make it consistent with Sydney, but it's a bit wrong to allow one node to run the network...
* max_validator_count is the maximum number of validators that are willing to join. But if it's not provided, we don't cap it. 
* removed slash for inactivity (zero)